### PR TITLE
update README.md install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install the quantmod R package directly from github, run the following in R:
 
 ```{r}
 library(devtools)
-install_github(repo="cmu-delphi/quantmod", subdir="R-package/quantmod")
+install_github(repo="cmu-delphi/quantmod", subdir="R-package/quantmod", ref="main")
 ```
 
 ### Install Gurobi for R


### PR DESCRIPTION
`install_github()` tries to look in branch `master` by default; we must point it to branch `main`.